### PR TITLE
Expanded content for DV_TEXT, DV_CODED_TEXT and DV_QUANTITY to match …

### DIFF
--- a/docs/serial_data_formats/master03-data_values.adoc
+++ b/docs/serial_data_formats/master03-data_values.adoc
@@ -327,5 +327,17 @@ a|
 }
 ----
 
+|`DV_ORDINAL`
+a|
+[source,json]
+----
+{
+    "\|ordinal": 1,
+    "\|value": "Absent",
+    "\|code": "at0004"
+}
+----
+
+
 |===
 

--- a/docs/simplified_im_b/master04-sim_data_types.adoc
+++ b/docs/simplified_im_b/master04-sim_data_types.adoc
@@ -28,7 +28,10 @@ The following shows the SDT serial formats for an `S_DV_TEXT` instance:
 [source,json]
 ----
 {
-    "a/b/c/d|value": "anxiety"
+    "a/b/c/d|value": "anxiety",
+    "a/b/c/d/_mapping:0|match": "=",
+    "a/b/c/d/_mapping:0/target|terminology": "SNOMED-CT",
+    "a/b/c/d/_mapping:0/target|code": "21794005"
 }
 ----
 
@@ -44,7 +47,10 @@ TBD: are the inner attributes supposed to have bars or not, i.e. "|value" etc?
         "b" : {
             "c": {
                 "d" : {
-                    "|value": "anxiety"
+                    "|value": "anxiety",
+                    "_mapping:0|match": "=",
+                    "_mapping:0/target|terminology": "SNOMED-CT",
+                    "_mapping:0/target|code": "21794005"
                 }
             }
         }
@@ -85,9 +91,13 @@ The following shows the SDT serial formats for an `S_DV_CODED_TEXT` instance:
 [source,json]
 ----
 {
-    "a/b/c/d|terminology": "snomed_ct",
+    "a/b/c/d|terminology": "SNOMED-CT",
     "a/b/c/d|code": "48694002",
-    "a/b/c/d|value": "anxiety"
+    "a/b/c/d|value": "anxiety",
+    "a/b/c/d/_mapping:0|match": "=",
+    "a/b/c/d/_mapping:0/target|terminology": "ICD-10",
+    "a/b/c/d/_mapping:0/target|code": "H234"
+
 }
 ----
 
@@ -103,9 +113,17 @@ TBD: are the inner attributes supposed to have bars or not, i.e. "|terminology" 
         "b" : {
             "c": {
                 "d" : {
-                    "|terminology": "snomed_ct",
+                    "|terminology": "SNOMED-CT",
                     "|code": "48694002",
-                    "|value": "anxiety"
+                    "|value": "anxiety",
+                    "_mapping" : [
+                        {
+                        "|match": "=",
+                        "target" {
+                            "|terminology": "ICD-10",
+                            "|code": "21794005"
+                        }
+                    }
                 }
             }
         }
@@ -121,7 +139,7 @@ TBD: are the inner attributes supposed to have bars or not, i.e. "|terminology" 
     "a" : {
         "b" : {
             "c": {
-                "d" : "snomed_ct::48694002|anxiety|"
+                "d" : "SNOMED-CT::48694002|anxiety|"
             }
         }
     }
@@ -149,8 +167,21 @@ The following shows the SDT serial formats for an `S_DV_QUANTITY` instance:
 {
     "a/b/c/d|magnitude": 125,
     "a/b/c/d|units":    "mm[Hg]",
-    "a/b/c/d|xx":       "xx_val", -- other DvQ fields
-    "a/b/c/d|yy":       "yy_val"
+    "a/b/c/d|precision":    1,
+    "a/b/c/d|normal_status":  "H",
+    "a/b/c/d|magnitude_status": "~",
+    "a/b/c/d/_normal_range/lower|magnitude": 2.5,
+    "a/b/c/d/_normal_range/lower|unit": "mmol/l",
+    "a/b/c/d/_normal_range/upper|magnitude": 6.6,
+    "a/b/c/d/_normal_range/upper|unit": "mmol/l",
+    "a/b/c/d/_other_reference_ranges:0/meaning|code": "VH",
+    "a/b/c/d/_other_reference_ranges:0/meaning|terminology": "local-ranges",
+    "a/b/c/d/_other_reference_ranges:0/meaning|value": "Very high",
+    "a/b/c/d/_other_reference_ranges:0/lower|magnitude": 10.5,
+    "a/b/c/d/_other_reference_ranges:0/lower|unit": "mmol/l",
+    "a/b/c/d/_other_reference_ranges:0/upper|magnitude": 16.6,
+    "a/b/c/d/_other_reference_ranges:0/upper|unit": "mmol/l"
+}
 }
 ----
 
@@ -166,10 +197,51 @@ TBD: are the inner attributes supposed to have bars or not, i.e. "|magnitude" et
         "b" : {
             "c": {
                 "d" : {
-                    "magnitude": 125,
-                    "units":     "mm[Hg]",
-                    "xx":        "xx_val",
-                    "yy":        "yy_val"
+                    "|magnitude": 125,
+                    "|units":     "mm[Hg]",
+                    "|normal_status": "H",
+                    "|magnitude_status": "~",
+                    "|precision" : 1,
+                    "_normal_range" : {
+                       "lower" : {
+                                "|magnitude": 3.5,
+                                "|unit": "mmol/l"
+                                },
+                        "upper" : {
+                            "|magnitude": 7.5,
+                            "|unit": "mmol/l"
+                            }
+                    },            
+                    "_other_reference_ranges" : [
+                        { //Text-only meaning
+                            "meaning": "Child",
+                            "lower" : {
+                                "|magnitude": 10.5,
+                                "|unit": "mmol/l"
+                                },
+                            "upper" : {
+                                "|magnitude": 10.5,
+                                "|unit": "mmol/l"
+                                },
+                                
+                        },
+                        { //Coded meaning
+                            "meaning":  {
+                                "|value": "African-American",
+                                "|terminology" : "SNOMED-CT",
+                                "|code" : "23123456"
+                            },
+                            "lower" : {
+                                "|magnitude": 0.5,
+                                "|unit": "mmol/l"
+                                },
+                            "upper" : {
+                                "|magnitude": 8.5,
+                                "|unit": "mmol/l"
+                                }                               
+                        }
+
+                    ]     
                 }
             }
         }
@@ -178,6 +250,8 @@ TBD: are the inner attributes supposed to have bars or not, i.e. "|magnitude" et
 ----
 
 ==== Regular structure + terse value form
+
+IMCN: ? Needs to handle precision
 
 [source,json]
 ----
@@ -215,8 +289,8 @@ The following shows the SDT serial formats for an `S_DV_PARSABLE` instance:
         "b" : {
             "c": {
                 "d" : {
-                    "formalism": "markdown",
-                    "value":     "This is some markdown https://somwehere.org[linked text]"
+                    "|formalism": "markdown",
+                    "|value":     "This is some markdown https://somwehere.org[linked text]"
                 }
             }
         }

--- a/docs/simplified_im_b/master04-sim_data_types.adoc
+++ b/docs/simplified_im_b/master04-sim_data_types.adoc
@@ -123,7 +123,7 @@ TBD: are the inner attributes supposed to have bars or not, i.e. "|terminology" 
                             "|terminology": "ICD-10",
                             "|code": "21794005"
                         }
-                    }
+                    ]
                 }
             }
         }
@@ -131,6 +131,36 @@ TBD: are the inner attributes supposed to have bars or not, i.e. "|terminology" 
 }
 ----
 
+==== Ehrscape STRUCTURED variant - Regular structure + regular value form
+
+[.tbd]
+TBD: are the inner attributes supposed to have bars or not, i.e. "|terminology" etc?
+
+[source,json]
+----
+{
+    "a" : {
+        "b" : [{
+            "c": [{
+                "d" : [{
+                    "|terminology": "SNOMED-CT",
+                    "|code": "48694002",
+                    "|value": "anxiety",
+                    "_mapping" : [
+                        {
+                        "|match": "=",
+                        "target" {
+                            "|terminology": "ICD-10",
+                            "|code": "21794005"
+                        }
+                    ]
+                }]
+            }]
+        }]
+    }
+}
+
+----
 ==== Regular structure + terse value form
 
 [source,json]
@@ -185,7 +215,7 @@ The following shows the SDT serial formats for an `S_DV_QUANTITY` instance:
 
 ----
 
-==== Regular structure + regular value form
+==== Ehrscape STRUCTURED variant - Regular structure + regular value form
 
 [.tbd]
 TBD: are the inner attributes supposed to have bars or not, i.e. "|magnitude" etc?
@@ -195,57 +225,117 @@ TBD: are the inner attributes supposed to have bars or not, i.e. "|magnitude" et
 ----
 {
     "a" : {
-        "b" : {
-            "c": {
-                "d" : {
+        "b" : [{
+            "c": [{
+                "d" : [{
                     "|magnitude": 125,
                     "|units":     "mm[Hg]",
                     "|normal_status": "H",
                     "|magnitude_status": "~",
-                    "_normal_range" : {
-                       "lower" : {
+                    "_normal_range" : [{
+                       "lower" : [{
                                 "|magnitude": 3.5,
                                 "|unit": "mmol/l"
-                                },
-                        "upper" : {
+                                }],
+                        "upper" : [{
                             "|magnitude": 7.5,
                             "|unit": "mmol/l"
-                            }
-                    },            
+                            }]
+                    }],            
                     "_other_reference_ranges" : [
                         { //Text-only meaning
                             "meaning": "Child",
-                            "lower" : {
+                            "lower" : [{
                                 "|magnitude": 10.5,
                                 "|unit": "mmol/l"
-                                },
-                            "upper" : {
+                                }],
+                            "upper" : [{
                                 "|magnitude": 10.5,
                                 "|unit": "mmol/l"
-                                },
+                                }],
                                 
                         },
                         { //Coded meaning
-                            "meaning":  {
+                            "meaning":  [{
                                 "|value": "African-American",
                                 "|terminology" : "SNOMED-CT",
                                 "|code" : "23123456"
-                            },
-                            "lower" : {
+                            }],
+                            "lower" : [{
                                 "|magnitude": 0.5,
                                 "|unit": "mmol/l"
-                                },
-                            "upper" : {
+                                }],
+                            "upper" : [{
                                 "|magnitude": 8.5,
                                 "|unit": "mmol/l"
-                                }                               
-                        }
+                                }]                               
+                        }]     
+                }]
+            }]
+        }]
+    }]
+}
+----
 
-                    ]     
-                }
+==== Regular structure + regular value form
+
+[.tbd]
+TBD: are the inner attributes supposed to have bars or not, i.e. "|magnitude" etc?
+
+
+[source,json]
+----
+{
+  "a" : {
+    "b" : {
+      "c": {
+        "d" : {
+          "|magnitude": 125,
+          "|units": "mm[Hg]",
+          "|normal_status": "H",
+          "|magnitude_status": "~",
+          "_normal_range" : {
+            "lower" : {
+                "|magnitude": 3.5,
+                "|unit": "mmol/l"
+            },
+            "upper" : {
+              "|magnitude": 7.5,
+              "|unit": "mmol/l"
             }
-        }
+          },            
+          "_other_reference_ranges" : [
+            { //Text-only meaning
+              "meaning": "Child",
+              "lower" : {
+                "|magnitude": 10.5,
+                "|unit": "mmol/l"
+              },
+              "upper" : {
+                "|magnitude": 10.5,
+                "|unit": "mmol/l"
+              }
+            },
+            { //Coded meaning
+              "meaning":  {
+                "|value": "African-American",
+                "|terminology" : "SNOMED-CT",
+                "|code" : "23123456"
+              },
+              "lower" : {
+                "|magnitude": 0.5,
+                "|unit": "mmol/l"
+                },
+              "upper" : {
+                "|magnitude": 8.5,
+                "|unit": "mmol/l"
+                }                               
+            }
+          ]
+        }     
+      }
     }
+  }
 }
 ----
 
@@ -264,17 +354,155 @@ TBD: are the inner attributes supposed to have bars or not, i.e. "|magnitude" et
 }
 ----
 
-=== S_DV_PARSABLE
 
-The following shows the SDT serial formats for an `S_DV_PARSABLE` instance:
+=== S_DV_COUNT
 
+The following shows the SDT serial formats for an `S_DV_COUNT` instance:
+
+==== Path structure + terse value form
+
+[source,json]
+----
+{
+    "a/b/c/d": "23",
+}
+----
 ==== Path structure + regular value form
 
 [source,json]
 ----
 {
-    "a/b/c/d|formalism": "markdown",
-    "a/b/c/d|value":     "This is some markdown https://somwehere.org[linked text]"
+    "a/b/c/d": "23",
+}
+----
+
+==== Regular structure + regular value form
+
+In theory, as a DV_ORDERED, DV_COUNT should support other attributes like magnitude_status, normal_status, normal_range etc but not tested yet.
+
+[source,json]
+----
+{
+  "a" : {
+    "b" : {
+      "c": {
+        "d" : 23
+      }
+    }
+  }
+}
+----
+
+==== Ehrscape STRUCTURED variant Regular structure + regular value form
+
+[NOTE]
+Better STRUCTURED (regular) format represents every branch as an array, regardless of whether single or multiple occurrence - needs clarification.
+
+In theory, as a DV_ORDERED, DV_COUNT should support other attributes like magnitude_status, normal_status, normal_range etc but not tested yet.
+
+[source,json]
+----
+{
+    "a" : {
+        "b" : [{
+            "c": [
+                "d" : 23
+            ],
+          }],
+      }]
+}
+----
+
+
+=== S_DV_ORDINAL
+
+The following shows the SDT serial formats for an `S_DV_ORDINAL` instance:
+
+==== Path structure + terse form
+
+[source,json]
+----
+{
+    "a/b/c/d": "1|at0004|Absent|",
+}
+----
+==== Path structure + regular value form
+
+[source,json]
+----
+{
+    "a/b/c/d|ordinal": 1,
+    "a/b/c/d|code": "at0004",
+    "a/b/c/d|value": "Absent",
+}
+----
+
+
+==== Regular structure + regular value form
+
+[source,json]
+----
+{
+  "a" : {
+      "b" : {
+          "c": {
+              "d" : {
+                  "|code": "at0066",
+                  "|value": "Absent",
+                  "|ordinal": 1 
+              } 
+          }
+      }
+  }
+}
+----
+
+==== Ehrscape variant STRUCTURED Regular structure + regular value form
+
+[NOTE]
+Better STRUCTURED (regular) format represents every branch as an array, regardless of whether single or multiple occurrence - needs clarification.
+
+[source,json]
+----
+{
+    "a" : {
+        "b" : [{
+            "c": [{
+                "d" : [{
+                       "|code": "at0066",
+                       "|value": "Absent",
+                       "|ordinal": 1 
+                  }]
+              }],
+          }],
+      }
+}
+----
+
+=== S_DV_IDENTIFIER
+
+The following shows the SDT serial formats for an `S_DV_IDENTIFIER` instance:
+
+
+==== Path structure + terse form
+[NOTE]
+Not supported in Better Ehrscape
+
+[source,json]
+----
+{
+    "a/b/c/d": "1|at0004|Absent|",
+}
+----
+==== Path structure + regular value form
+
+[source,json]
+----
+{
+    "a/b/c/d|identifier": 1,
+    "a/b/c/d|type": "GMC number",
+    "a/b/c/d|assigner": "GMC-UK",
+    "a/b/c/d|issuer": "GMC-UK",
 }
 ----
 
@@ -284,17 +512,44 @@ The following shows the SDT serial formats for an `S_DV_PARSABLE` instance:
 ----
 {
     "a" : {
-        "b" : {
-            "c": {
-                "d" : {
-                    "|formalism": "markdown",
-                    "|value":     "This is some markdown https://somwehere.org[linked text]"
-                }
-            }
-        }
-    }
+      "b" : {
+          "c": {
+              "d" : {
+                "|identifier": 1,
+                "|type": "GMC number",
+                "|assigner": "GMC-UK",
+                "|issuer": "GMC-UK"
+              },
+            },
+        },
+      }
 }
 ----
+
+==== Ehrscape Regular (STRUCTURED) structure + regular value form
+
+[NOTE]
+Better STRUCTURED (regular) format represents every branch as an array, regardless of whether single or multiple occurrence - needs clarification.
+
+[source,json]
+----
+{
+    "a" : {
+      "b" : [{
+          "c": [{
+              "d" : [{
+                "|identifier": 1,
+                "|type": "GMC number",
+                "|assigner": "GMC-UK",
+                "|issuer": "GMC-UK"
+              }],
+            }],
+        }],
+      }
+}
+----
+
+
 
 == Class Definitions
 

--- a/docs/simplified_im_b/master04-sim_data_types.adoc
+++ b/docs/simplified_im_b/master04-sim_data_types.adoc
@@ -153,6 +153,7 @@ The following shows the SDT serial formats for an `S_DV_QUANTITY` instance:
 
 ==== Path structure + terse value form
 
+
 [source,json]
 ----
 {
@@ -167,7 +168,6 @@ The following shows the SDT serial formats for an `S_DV_QUANTITY` instance:
 {
     "a/b/c/d|magnitude": 125,
     "a/b/c/d|units":    "mm[Hg]",
-    "a/b/c/d|precision":    1,
     "a/b/c/d|normal_status":  "H",
     "a/b/c/d|magnitude_status": "~",
     "a/b/c/d/_normal_range/lower|magnitude": 2.5,
@@ -182,13 +182,14 @@ The following shows the SDT serial formats for an `S_DV_QUANTITY` instance:
     "a/b/c/d/_other_reference_ranges:0/upper|magnitude": 16.6,
     "a/b/c/d/_other_reference_ranges:0/upper|unit": "mmol/l"
 }
-}
+
 ----
 
 ==== Regular structure + regular value form
 
 [.tbd]
 TBD: are the inner attributes supposed to have bars or not, i.e. "|magnitude" etc?
+
 
 [source,json]
 ----
@@ -201,7 +202,6 @@ TBD: are the inner attributes supposed to have bars or not, i.e. "|magnitude" et
                     "|units":     "mm[Hg]",
                     "|normal_status": "H",
                     "|magnitude_status": "~",
-                    "|precision" : 1,
                     "_normal_range" : {
                        "lower" : {
                                 "|magnitude": 3.5,
@@ -250,8 +250,6 @@ TBD: are the inner attributes supposed to have bars or not, i.e. "|magnitude" et
 ----
 
 ==== Regular structure + terse value form
-
-IMCN: ? Needs to handle precision
 
 [source,json]
 ----


### PR DESCRIPTION
…current Better formats. I would suggest retaining the | marker on leaf nodes for now, to preserve backward compatibility. It may also assist conversion between the Path and Regular structures. Now working on COUNT,  NULL,  and ORDINAL